### PR TITLE
TrigonometriskPunkt -> man_made=survey_point

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Paramters:
   * <code>AdministrativeOmrader</code> - Municipal boundaries. Rough boundaries, so please do not import into OSM.
   * <code>Arealdekke</code> - This is the topo data used in the N50 import (default if no category given).
   * <code>BygningerOgAnlegg</code> - Useful additional objects such as quay, pier, dam and various public services.
-  * <code>Hoyde</code> - Peaks/hills.
+  * <code>Hoyde</code> - Peaks/hills and survey points.
   * <code>Restriksjonsomrader</code> - Military areas.
   * <code>Samferdsel</code> - Tracks and paths (rough topology).
   * <code>Stedsnavn</code> - Place names (no OSM tagging). Please use the [SSR import](https://wiki.openstreetmap.org/wiki/No:Import_av_stedsnavn_fra_SSR2) instead.

--- a/n50osm.py
+++ b/n50osm.py
@@ -97,7 +97,7 @@ osm_tags = {
 	# Hoyde
 
 	'Terrengpunkt':			{ 'natural': 'hill' },
-	'TrigonometriskPunkt':	{ 'natural': 'hill' },
+	'TrigonometriskPunkt':	{'man_made': 'survey_point', 'natural': 'hill'},
 
 	# Restriksjonsomrader
 


### PR DESCRIPTION
Map "TrigonometriskPunkt" to`man_made=survey_point` in addition to `natural=hill`, which is the current behaviour.

Was also debating with myself whether to add a `fixme` tag informing about the possibility of survey points not being on the top of a hill. But, if there are many survey points in a municipality, that might result in a lot of false positives to go through, so I decided against it for now. Any opinion on this?